### PR TITLE
Limiting events per hour to 10, adding version id

### DIFF
--- a/Runtime/VspAttribution.cs
+++ b/Runtime/VspAttribution.cs
@@ -6,7 +6,8 @@ namespace UnityEngine.VspAttribution
 {
 	public static class VspAttribution
 	{
-		const int k_MaxEventsPerHour = 20;
+		const int k_VersionId = 4;
+		const int k_MaxEventsPerHour = 10;
 		const int k_MaxNumberOfElements = 1000;
 
 		const string k_VendorKey = "unity.vsp-attribution";
@@ -16,10 +17,10 @@ namespace UnityEngine.VspAttribution
 		{
 #if UNITY_EDITOR
 			AnalyticsResult result = EditorAnalytics.RegisterEventWithLimit(k_EventName, k_MaxEventsPerHour,
-				k_MaxNumberOfElements, k_VendorKey);
+				k_MaxNumberOfElements, k_VendorKey, k_VersionId);
 #else // IF !UNITY_EDITOR
 			AnalyticsResult result = Analytics.Analytics.RegisterEvent(k_EventName, k_MaxEventsPerHour,
-				k_MaxNumberOfElements, k_VendorKey);
+				k_MaxNumberOfElements, k_VendorKey, k_VersionId);
 #endif
 
 			bool isResultOk = result == AnalyticsResult.Ok;
@@ -80,9 +81,9 @@ namespace UnityEngine.VspAttribution
 
 #if UNITY_EDITOR
 				// Send the Attribution Event
-				var eventResult = EditorAnalytics.SendEventWithLimit(k_EventName, eventData);
+				var eventResult = EditorAnalytics.SendEventWithLimit(k_EventName, eventData, k_VersionId);
 #else // IF !UNITY_EDITOR
-				var eventResult = Analytics.Analytics.SendEvent(k_EventName, eventData);
+				var eventResult = Analytics.Analytics.SendEvent(k_EventName, eventData, k_VersionId);
 #endif
 				return eventResult;
 			}


### PR DESCRIPTION
Changing limits to 10, as every incoming analytics event should be valid.
Adding version id as per table indexing.